### PR TITLE
Rename generate file and factory function

### DIFF
--- a/pkg/cli/alpha.go
+++ b/pkg/cli/alpha.go
@@ -29,15 +29,7 @@ const (
 )
 
 var alphaCommands = []*cobra.Command{
-	newAlphaCommand(),
-	alpha.NewScaffoldCommand(),
-}
-
-func newAlphaCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		// TODO: If we need to create alpha commands please add a new file for each command
-	}
-	return cmd
+	alpha.NewGenerateCommand(),
 }
 
 func (c *CLI) newAlphaCmd() *cobra.Command {

--- a/pkg/cli/alpha/generate.go
+++ b/pkg/cli/alpha/generate.go
@@ -34,7 +34,7 @@ import (
 //
 // Technically, implementing functions that allow re-scaffolding with the exact plugins and project-specific
 // code of external projects is not feasible within Kubebuilder’s current design.
-func NewScaffoldCommand() *cobra.Command {
+func NewGenerateCommand() *cobra.Command {
 	opts := internal.Generate{}
 	scaffoldCmd := &cobra.Command{
 		Use:   "generate",


### PR DESCRIPTION
This commit renames the pkg/cli/alpha/command.go to generate.go and also the factory function NewScaffoldCommand() to NewGenerateCommand(), to make the names more descriptive.

Closes #5 