### PR TITLE
Define and add `alpha update` command

### DIFF
--- a/pkg/cli/alpha.go
+++ b/pkg/cli/alpha.go
@@ -29,15 +29,7 @@ const (
 )
 
 var alphaCommands = []*cobra.Command{
-	newAlphaCommand(),
-	alpha.NewScaffoldCommand(),
-}
-
-func newAlphaCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		// TODO: If we need to create alpha commands please add a new file for each command
-	}
-	return cmd
+	alpha.NewGenerateCommand(),
 }
 
 func (c *CLI) newAlphaCmd() *cobra.Command {

--- a/pkg/cli/alpha.go
+++ b/pkg/cli/alpha.go
@@ -30,6 +30,7 @@ const (
 
 var alphaCommands = []*cobra.Command{
 	alpha.NewGenerateCommand(),
+	alpha.NewUpdateCommand(),
 }
 
 func (c *CLI) newAlphaCmd() *cobra.Command {

--- a/pkg/cli/alpha/generate.go
+++ b/pkg/cli/alpha/generate.go
@@ -34,9 +34,9 @@ import (
 //
 // Technically, implementing functions that allow re-scaffolding with the exact plugins and project-specific
 // code of external projects is not feasible within Kubebuilder’s current design.
-func NewScaffoldCommand() *cobra.Command {
+func NewGenerateCommand() *cobra.Command {
 	opts := internal.Generate{}
-	scaffoldCmd := &cobra.Command{
+	generateCmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Re-scaffold an existing Kuberbuilder project",
 		Long: `It's an experimental feature that has the purpose of re-scaffolding the whole project from the scratch 
@@ -54,12 +54,12 @@ Then we will re-scaffold the project by Kubebuilder in the directory specified b
 			}
 		},
 	}
-	scaffoldCmd.Flags().StringVar(&opts.InputDir, "input-dir", "",
+	generateCmd.Flags().StringVar(&opts.InputDir, "input-dir", "",
 		"Specifies the full path to a Kubebuilder project file. If not provided, "+
 			"the current working directory is used.")
-	scaffoldCmd.Flags().StringVar(&opts.OutputDir, "output-dir", "",
+	generateCmd.Flags().StringVar(&opts.OutputDir, "output-dir", "",
 		"Specifies the full path where the scaffolded files will be output. "+
 			"Defaults to a directory within the current working directory.")
 
-	return scaffoldCmd
+	return generateCmd
 }

--- a/pkg/cli/alpha/internal/update.go
+++ b/pkg/cli/alpha/internal/update.go
@@ -1,0 +1,17 @@
+package internal
+
+import (
+	"fmt"
+)
+
+type Update struct {
+	// TODO: populate the struct
+	Field string
+}
+
+func (opts *Update) Update() error {
+	// TODO: add implementation logic
+	fmt.Println("WIP...")
+
+	return nil
+}

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -1,0 +1,29 @@
+package alpha
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal"
+)
+
+func NewUpdateCommand() *cobra.Command {
+	opts := internal.Update{}
+	updateCmd := &cobra.Command{
+		Use:   "update",
+		Short: "TODO: add a short description of the command",
+		Long: `TODO: add a long description of the command.
+Provide usage examples.`,
+		// 	TODO: add validation here
+		//	PreRunE: func(_ *cobra.Command, _ []string) error {
+		//		return opts.Validate()
+		//	},
+		Run: func(_ *cobra.Command, _ []string) {
+			if err := opts.Update(); err != nil {
+				log.Fatalf("Failed to execute: %s", err)
+			}
+		},
+	}
+	// TODO: add flags here later
+
+	return updateCmd
+}


### PR DESCRIPTION
This PR sets the starting for the `alpha update` command. It's a WIP.

I also renames the `scaffoldCmd` variables to `generateCmd,` to be more descriptive.

Closes #2 