### PR TITLE
Add `--from-version` flag and implement logic for extracting `cliVersion` from PROJECT file

### DIFF
--- a/pkg/cli/alpha/internal/update.go
+++ b/pkg/cli/alpha/internal/update.go
@@ -2,16 +2,34 @@ package internal
 
 import (
 	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"sigs.k8s.io/kubebuilder/v4/pkg/config/store/yaml"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
 
 type Update struct {
 	// TODO: populate the struct
-	Field string
+	FromVersion string
 }
 
 func (opts *Update) Update() error {
 	// TODO: add implementation logic
 	fmt.Println("WIP...")
+
+	projectConfigFile := yaml.New(machinery.Filesystem{FS: afero.NewOsFs()})
+	if err := projectConfigFile.LoadFrom(yaml.DefaultPath); err != nil { // TODO: assess if DefaultPath could be renamed to ConfigFilePath
+		return fmt.Errorf("TODO: add error message: %w", err)
+	}
+
+	cliVersion := projectConfigFile.Config().GetCliVersion()
+
+	// TODO: add logic for overriding the cliVersion from the PROJECT file with the
+	// value passed to the --from-version flag just so that projects prior to 4.6.0
+	// can use it.
+
+	log.Infof("TODO: add message for CLI version being used: %s", cliVersion)
 
 	return nil
 }

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -19,11 +19,13 @@ Provide usage examples.`,
 		//	},
 		Run: func(_ *cobra.Command, _ []string) {
 			if err := opts.Update(); err != nil {
-				log.Fatalf("Failed to execute: %s", err)
+				log.Fatalf("TODO: fail message: %s", err)
 			}
 		},
 	}
 	// TODO: add flags here later
+	updateCmd.Flags().StringVar(&opts.FromVersion, "from-version", "",
+		"TODO: add usage of the --from-version tag here")
 
 	return updateCmd
 }


### PR DESCRIPTION
This commit implements the yaml store for loading the PROJECT config file and adds the `cliVersion` variable to hold the cliVersion field extracted using the `GetCliVersion()` function that's already present in the codebase:

```
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ ../../bin/kubebuilder alpha update
WIP...
INFO TODO: add message for CLI version being used: (devel) 
```
It also adds the --from-version flag:

```
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ ../../bin/kubebuilder alpha update -h
TODO: add a long description of the command.
Provide usage examples.

Usage:
  kubebuilder alpha update [flags]

Flags:
      --from-version string   TODO: add usage of the --from-version tag here
  -h, --help                  help for update
```

Closes #4 
Closes #3 