### PR TITLE
Add binary download, temp dir creation, copy to file and permissions

### DIFF
--- a/pkg/cli/alpha/internal/update.go
+++ b/pkg/cli/alpha/internal/update.go
@@ -2,6 +2,11 @@ package internal
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -14,23 +19,76 @@ type Update struct {
 }
 
 func (opts *Update) Update() error {
-	fmt.Println("WIP...") // TODO: remove this print later
 
 	projectConfigFile := yaml.New(machinery.Filesystem{FS: afero.NewOsFs()})
 	if err := projectConfigFile.LoadFrom(yaml.DefaultPath); err != nil { // TODO: assess if DefaultPath could be renamed to ConfigFilePath
-		return fmt.Errorf("Fail to run the command: %w", err) // TODO: improve the error message
+		return fmt.Errorf("Fail to run command: %w", err)
 	}
 
 	cliVersion := projectConfigFile.Config().GetCliVersion()
 
 	if opts.FromVersion != "" {
-		// TODO: add normalization here
-		// users may input "4.5.0" or "v4.5.0"
-		// so better check for that
-		log.Infof("Overriding PROJECT cliVersion from %s to %s", cliVersion, opts.FromVersion) // TODO: improve override message
+		if !strings.HasPrefix(opts.FromVersion, "v") {
+			opts.FromVersion = "v" + opts.FromVersion
+		}
+		log.Infof("Overriding cliVersion field %s from PROJECT file with --from-version %s", cliVersion, opts.FromVersion)
+		cliVersion = opts.FromVersion
 	} else {
-		log.Infof("CLI version being used: %s", cliVersion) // TODO: improve the log message
+		log.Infof("Using CLI version from PROJECT file: %s", cliVersion)
 	}
 
+	tempDir, err := opts.downloadKubebuilderBinary(cliVersion)
+	if err != nil {
+		return fmt.Errorf("Failed to download Kubebuilder %s binary: %w", cliVersion, err)
+	}
+
+	log.Infof("Downloaded binary kept at %s for debugging purposes", tempDir)
+
 	return nil
+}
+
+func (opts *Update) downloadKubebuilderBinary(version string) (string, error) {
+
+	cliVersion := version
+
+	url := fmt.Sprintf("https://github.com/kubernetes-sigs/kubebuilder/releases/download/%s/kubebuilder_%s_%s",
+		cliVersion, runtime.GOOS, runtime.GOARCH)
+
+	log.Infof("Downloading the Kubebuilder %s binary from: %s", cliVersion, url)
+
+	fs := afero.NewOsFs()
+	tempDir, err := afero.TempDir(fs, "", "kubebuilder"+cliVersion+"-")
+	if err != nil {
+		return "", fmt.Errorf("Failed to create temporary directory: %w", err)
+	}
+
+	binaryPath := tempDir + "/kubebuilder"
+	file, err := os.Create(binaryPath)
+	if err != nil {
+		return "", fmt.Errorf("Failed to create the binary file: %w", err)
+	}
+	defer file.Close()
+
+	response, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("Failed to download the binary: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Failed to download the binary: HTTP %d", response.StatusCode)
+	}
+
+	_, err = io.Copy(file, response.Body)
+	if err != nil {
+		return "", fmt.Errorf("Failed to write the binary content to file: %w", err)
+	}
+
+	if err := os.Chmod(binaryPath, 0755); err != nil {
+		return "", fmt.Errorf("Failed to make binary executable: %w", err)
+	}
+
+	log.Infof("Kubebuilder version %s succesfully downloaded to %s", cliVersion, binaryPath)
+
+	return tempDir, nil
 }

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -19,7 +19,7 @@ Provide usage examples.`,
 		//	},
 		Run: func(_ *cobra.Command, _ []string) {
 			if err := opts.Update(); err != nil {
-				log.Fatalf("TODO: fail message: %s", err)
+				log.Fatalf("%s", err)
 			}
 		},
 	}


### PR DESCRIPTION
This commit adds the functionality necessary for constructing the URL for downloading the correct binary, create the temp dir and the file to store the binary, and give it permission to execute.

As an MVP, this PR meets the acceptance criteria for the download features of the `alpha update` command:

✔️  The command succeeds if the PROJECT file contains a valid version:
```
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ ../../bin/kubebuilder alpha update
INFO Using CLI version from PROJECT file: v4.6.0  
INFO Downloading the Kubebuilder v4.6.0 binary from: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.6.0/kubebuilder_linux_amd64 
INFO Kubebuilder version v4.6.0 succesfully downloaded to /tmp/kubebuilderv4.6.0-196632778/kubebuilder 
INFO Downloaded binary kept at /tmp/kubebuilderv4.6.0-196632778 for debugging purposes 
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ cd /tmp/kubebuilderv4.6.0-196632778/
vitorfloriano@pc:/tmp/kubebuilderv4.6.0-196632778$ l
kubebuilder*
vitorfloriano@pc:/tmp/kubebuilderv4.6.0-196632778$ ./kubebuilder version
Version: cmd.version{KubeBuilderVersion:"4.6.0", KubernetesVendor:"1.33.0", GitCommit:"cd90bd82a2d692fbf63ba0231699e2e3dc0b6a08", BuildDate:"2025-05-24T23:24:02Z", GoOs:"linux", GoArch:"amd64"}
```
✔️  The command succeeds if a valid version is passed to the --from-version flag:
```
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ ../../bin/kubebuilder alpha update --from-version 4.5.0
INFO Overriding cliVersion field (devel) from PROJECT file with --from-version v4.5.0 
INFO Downloading the Kubebuilder v4.5.0 binary from: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.5.0/kubebuilder_linux_amd64 
INFO Kubebuilder version v4.5.0 succesfully downloaded to /tmp/kubebuilderv4.5.0-144764142/kubebuilder 
INFO Downloaded binary kept at /tmp/kubebuilderv4.5.0-144764142 for debugging purposes 
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ cd /tmp/kubebuilder
kubebuilder(devel)-056894331/ kubebuilder(devel)-203980003/ kubebuilder(devel)-517400385/ kubebuilder(devel)-644356646/ kubebuilderv4.5.0-235002695/  
kubebuilder(devel)-086421731/ kubebuilder(devel)-476490852/ kubebuilder(devel)-597051460/ kubebuilderv4.5.0-144764142/  kubebuilderv4.5.0-358255003/  
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ cd /tmp/kubebuilderv4.5.0-144764142/
vitorfloriano@pc:/tmp/kubebuilderv4.5.0-144764142$ l
kubebuilder*
vitorfloriano@pc:/tmp/kubebuilderv4.5.0-144764142$ ./kubebuilder version
Version: main.version{KubeBuilderVersion:"4.5.0", KubernetesVendor:"1.31.0", GitCommit:"7153119ca900994b70507edbde59771ac824f2d9", BuildDate:"2025-01-21T08:46:54Z", GoOs:"linux", GoArch:"amd64"}
```
✔️  The command succesfully overrides the version in the PROJECT file if the version passed to --from-version is valid:
```
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ ../../bin/kubebuilder alpha update --from-version 4.5.0
INFO Overriding cliVersion field v4.6.0 from PROJECT file with --from-version v4.5.0 
INFO Downloading the Kubebuilder v4.5.0 binary from: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.5.0/kubebuilder_linux_amd64 
INFO Kubebuilder version v4.5.0 succesfully downloaded to /tmp/kubebuilderv4.5.0-228616281/kubebuilder 
INFO Downloaded binary kept at /tmp/kubebuilderv4.5.0-228616281 for debugging purposes 
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ cd /tmp/kubebuilderv4.5.0-228616281/
vitorfloriano@pc:/tmp/kubebuilderv4.5.0-228616281$ l
kubebuilder*
vitorfloriano@pc:/tmp/kubebuilderv4.5.0-228616281$ ./kubebuilder version
Version: main.version{KubeBuilderVersion:"4.5.0", KubernetesVendor:"1.31.0", GitCommit:"7153119ca900994b70507edbde59771ac824f2d9", BuildDate:"2025-01-21T08:46:54Z", GoOs:"linux", GoArch:"amd64"}
```
✔️ The command fails if the CLI version is not valid:
```
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ ../../bin/kubebuilder alpha update
INFO Using CLI version from PROJECT file: (devel) 
INFO Downloading the Kubebuilder (devel) binary from: https://github.com/kubernetes-sigs/kubebuilder/releases/download/(devel)/kubebuilder_linux_amd64 
FATA Failed to download Kubebuilder (devel) binary: Failed to download the binary: HTTP 404 
```
✔️ The command also fails if no argument is passed to the --from-version flag:
```
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ ../../bin/kubebuilder alpha update --from-version
Error: flag needs an argument: --from-version
Usage:
  kubebuilder alpha update [flags]

Flags:
      --from-version string   TODO: add usage of the --from-version tag here
  -h, --help                  help for update

Global Flags:
      --plugins strings   plugin keys to be used for this subcommand execution

FATA error executing command: flag needs an argument: --from-version 
```
✔️ The command succesfully creates a unique temporary directory to store the downloaded binary:
```
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ ../../bin/kubebuilder alpha update --from-version 4.5.0
INFO Overriding cliVersion field v4.6.0 from PROJECT file with --from-version v4.5.0 
INFO Downloading the Kubebuilder v4.5.0 binary from: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.5.0/kubebuilder_linux_amd64 
INFO Kubebuilder version v4.5.0 succesfully downloaded to /tmp/kubebuilderv4.5.0-228616281/kubebuilder 
INFO Downloaded binary kept at /tmp/kubebuilderv4.5.0-228616281 for debugging purposes 
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ cd /tmp/kubebuilderv4.5.0-228616281/
vitorfloriano@pc:/tmp/kubebuilderv4.5.0-228616281$ l
kubebuilder*
vitorfloriano@pc:/tmp/kubebuilderv4.5.0-228616281$ ./kubebuilder version
Version: main.version{KubeBuilderVersion:"4.5.0", KubernetesVendor:"1.31.0", GitCommit:"7153119ca900994b70507edbde59771ac824f2d9", BuildDate:"2025-01-21T08:46:54Z", GoOs:"linux", GoArch:"amd64"}  
```
Closes #14 
Closes #15 
Closes #16 
Closes #17 