### PR TITLE
✨ Add function to checkout upgrade off ancestor

### DIFF
--- a/pkg/cli/alpha/internal/update.go
+++ b/pkg/cli/alpha/internal/update.go
@@ -56,6 +56,10 @@ func (opts *Update) Update() error {
 		return fmt.Errorf("failed to checkout current off ancestor: %w", err)
 	}
 
+	if err := opts.checkoutUpgradeOffAncestor(); err != nil {
+		return fmt.Errorf("failed to checkout upgrade off ancestor: %w", err)
+	}
+
 	return nil
 }
 
@@ -161,7 +165,7 @@ func (opts *Update) checkoutCurrentOffAncestor() error {
 	if err := gitCmd.Run(); err != nil {
 		return fmt.Errorf("failed to checkout current branch off ancestor: %w", err)
 	}
-	log.Info("Sucessfully checked out current branch off ancestor")
+	log.Info("Successfully checked out current branch off ancestor")
 
 	gitCmd = exec.Command("git", "checkout", "master", "--", ".")
 	if err := gitCmd.Run(); err != nil {
@@ -180,6 +184,25 @@ func (opts *Update) checkoutCurrentOffAncestor() error {
 		return fmt.Errorf("failed to commit changes: %w", err)
 	}
 	log.Info("Successfully commited changes in current")
+
+	return nil
+}
+
+func (opts *Update) checkoutUpgradeOffAncestor() error {
+	gitCmd := exec.Command("git", "checkout", "-b", "upgrade", "ancestor")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to checkout upgrade branch off ancestor: %w", err)
+	}
+	log.Info("Successfully checked out upgrade branch off ancestor")
+
+	cmd := exec.Command("kubebuilder", "alpha", "generate")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run alpha generate on upgrade branch: %w", err)
+	}
+	log.Info("Successfully ran alpha generate on upgrade branch")
 
 	return nil
 }


### PR DESCRIPTION
This PR adds the functionality for checking out the `upgrade` branch off `ancestor` and then run `alpha generate` using the current version of the Kubebuilder cli.
```
vitorfloriano@PMI14:~/go/src/github.com/vitorfloriano/kubebuilder/testdata/project-v4$ ../../bin/kubebuilder alpha update --from-version 4.6.0
INFO Overriding cliVersion field (devel) from PROJECT file with --from-version v4.6.0 
INFO Downloading the Kubebuilder v4.6.0 binary from: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.6.0/kubebuilder_linux_amd64 
INFO Kubebuilder version v4.6.0 succesfully downloaded to /tmp/kubebuilderv4.6.0-932466097/kubebuilder 
INFO Downloaded binary kept at /tmp/kubebuilderv4.6.0-932466097 for debugging purposes 
INFO Created and checked out ancestor branch      
...
...
...
INFO Successfully ran alpha generate using Kubebuilder v4.6.0 
INFO Successfully staged all changes in ancestor  
INFO Successfully commited changes in ancestor    
INFO Successfully checked out current branch off ancestor 
INFO Successfully checked out content from main onto current branch 
INFO Successfully staged all changes in current   
INFO Successfully commited changes in current     
INFO Successfully checked out upgrade branch off ancestor 
...
...
...
INFO Successfully ran alpha generate on upgrade branch 
```
Closes #25 
