### PR TITLE
add --from-branch flag and input validation

### DIFF
--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -73,5 +73,9 @@ Examples:
 	updateCmd.Flags().StringVar(&opts.FromVersion, "from-version", "",
 		"Kubebuilder binary release version to upgrade from. Should match the version used to init the project.")
 
+	// Flag to specify the branch to use as current state for the update
+	updateCmd.Flags().StringVar(&opts.FromBranch, "from-branch", "",
+		"Git branch to use as current state of the project for the update.")
+
 	return updateCmd
 }


### PR DESCRIPTION
This PR introduces the ability to specify a branch for updates and adds input validation. 

The most important changes include adding support for the `--from-branch` flag, implementing validation for the branch and repository state, and improving the update process to use the specified branch instead of assuming `master` as a default.

It also adds input validation for the `--from-version` flag, checking if the value passed is in a valid SemVer format, and if the version specified has a binary available for download in the releases.

Closes #30 