### PR TITLE
:seedling: (alpha): add e2e test for alpha update command

### DIFF
--- a/test/e2e/alphaupdate/e2e_suite_test.go
+++ b/test/e2e/alphaupdate/e2e_suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alphaupdate
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Run e2e tests using the Ginkgo runner.
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	_, _ = fmt.Fprintf(GinkgoWriter, "Starting kubebuilder suite test for the alpha update command\n")
+	RunSpecs(t, "Kubebuilder alpha update suite")
+}

--- a/test/e2e/alphaupdate/update_test.go
+++ b/test/e2e/alphaupdate/update_test.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alphaupdate
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
+	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
+)
+
+const (
+	fromVersion = "v4.5.2"
+	toVersion   = "v4.6.0"
+)
+
+var _ = Describe("kubebuilder", func() {
+	Context("alpha update", func() {
+		var (
+			kbc             *utils.TestContext
+			mockProjectDir  string
+			kbOldBinaryPath string
+		)
+
+		BeforeEach(func() {
+			var err error
+			By("setting up test context for kubebuilder binary management")
+			kbc, err = utils.NewTestContext(pluginutil.KubebuilderBinName, "GO111MODULE=on")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(kbc.Prepare()).To(Succeed())
+
+			By("creating isolated mock project directory in /tmp to avoid git conflicts")
+			mockProjectDir, err = os.MkdirTemp("", "kubebuilder-mock-project-")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("downloading kubebuilder v4.5.2 binary to isolated /tmp directory")
+			kbOldBinaryPath, err = downloadKubebuilder()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			By("cleaning up test artifacts")
+			if mockProjectDir != "" {
+				_ = os.RemoveAll(mockProjectDir)
+			}
+			if kbOldBinaryPath != "" {
+				_ = os.RemoveAll(filepath.Dir(kbOldBinaryPath))
+			}
+			kbc.Destroy()
+		})
+
+		It("should update project from v4.5.2 to v4.6.0 preserving custom code", func() {
+			By("creating mock project with kubebuilder v4.5.2")
+			createMockProject(mockProjectDir, kbOldBinaryPath)
+
+			By("injecting custom code in API and controller")
+			injectCustomCode(mockProjectDir)
+
+			By("initializing git repository and committing mock project")
+			initializeGitRepo(mockProjectDir)
+
+			By("running alpha update from v4.5.2 to v4.6.0")
+			runAlphaUpdate(kbc, mockProjectDir)
+
+			By("validating custom code preservation")
+			validateCustomCodePreservation(mockProjectDir)
+		})
+	})
+})
+
+// downloadKubebuilder downloads the --from-version kubebuilder binary to a temporary directory
+func downloadKubebuilder() (string, error) {
+	binaryDir, err := os.MkdirTemp("", "kubebuilder-v4.5.2-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create binary directory: %w", err)
+	}
+
+	url := fmt.Sprintf(
+		"https://github.com/kubernetes-sigs/kubebuilder/releases/download/%s/kubebuilder_linux_amd64",
+		fromVersion,
+	)
+	binaryPath := filepath.Join(binaryDir, "kubebuilder")
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("failed to download kubebuilder %s: %w", fromVersion, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to download kubebuilder %s: HTTP %d", fromVersion, resp.StatusCode)
+	}
+
+	file, err := os.Create(binaryPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create binary file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	_, err = io.Copy(file, resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to write binary: %w", err)
+	}
+
+	err = os.Chmod(binaryPath, 0o755)
+	if err != nil {
+		return "", fmt.Errorf("failed to make binary executable: %w", err)
+	}
+
+	return binaryPath, nil
+}
+
+func createMockProject(projectDir, binaryPath string) {
+	err := os.Chdir(projectDir)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("running kubebuilder init")
+	cmd := exec.Command(binaryPath, "init", "--domain", "example.com", "--repo", "github.com/example/test-operator")
+	cmd.Dir = projectDir
+	_, err = cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+
+	By("running kubebuilder create api")
+	cmd = exec.Command(
+		binaryPath, "create", "api",
+		"--group", "webapp",
+		"--version", "v1",
+		"--kind", "TestOperator",
+		"--resource", "--controller",
+	)
+	cmd.Dir = projectDir
+	_, err = cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+
+	By("running make all")
+	cmd = exec.Command("make", "all")
+	cmd.Dir = projectDir
+	_, err = cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func injectCustomCode(projectDir string) {
+	typesFile := filepath.Join(projectDir, "api", "v1", "testoperator_types.go")
+	err := pluginutil.InsertCode(
+		typesFile,
+		"Foo string `json:\"foo,omitempty\"`",
+		"\n\t// +kubebuilder:validation:Minimum=0"+
+			"\n\t// +kubebuilder:validation:Maximum=3"+
+			"\n\t// +kubebuilder:default=1"+
+			"\n\t// Size is the size of the memcached deployment"+
+			"\n\tSize int32 `json:\"size,omitempty\"`",
+	)
+	Expect(err).NotTo(HaveOccurred())
+	controllerFile := filepath.Join(projectDir, "internal", "controller", "testoperator_controller.go")
+	err = pluginutil.InsertCode(
+		controllerFile,
+		"// TODO(user): your logic here",
+		"// Custom reconciliation logic\n\tlog := ctrl.LoggerFrom(ctx)"+
+			"\n\tlog.Info(\"Reconciling TestOperator\")"+
+			"\n\n\t// Fetch the TestOperator instance"+
+			"\n\ttestOperator := &webappv1.TestOperator{}"+
+			"\n\terr := r.Get(ctx, req.NamespacedName, testOperator)"+
+			"\n\tif err != nil {"+
+			"\n\t\treturn ctrl.Result{}, client.IgnoreNotFound(err)"+
+			"\n\t}"+
+			"\n\n\t// Custom logic: log the size field"+
+			"\n\tlog.Info(\"TestOperator size\", \"size\", testOperator.Spec.Size)",
+	)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func initializeGitRepo(projectDir string) {
+	By("initializing git repository")
+	cmd := exec.Command("git", "init")
+	cmd.Dir = projectDir
+	_, err := cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+
+	cmd = exec.Command("git", "config", "user.email", "test@example.com")
+	cmd.Dir = projectDir
+	_, err = cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+
+	cmd = exec.Command("git", "config", "user.name", "Test User")
+	cmd.Dir = projectDir
+	_, err = cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+
+	By("adding all files to git")
+	cmd = exec.Command("git", "add", "-A")
+	cmd.Dir = projectDir
+	_, err = cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+
+	By("committing initial project state")
+	cmd = exec.Command("git", "commit", "-m", "Initial project with custom code")
+	cmd.Dir = projectDir
+	_, err = cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func runAlphaUpdate(kbc *utils.TestContext, projectDir string) {
+	err := os.Chdir(projectDir)
+	Expect(err).NotTo(HaveOccurred())
+	cmd := exec.Command(kbc.BinaryName, "alpha", "update", "--from-version", fromVersion, "--to-version", toVersion)
+	cmd.Dir = projectDir
+	output, err := cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), "Alpha update failed: %s", string(output))
+}
+
+func validateCustomCodePreservation(projectDir string) {
+	typesFile := filepath.Join(projectDir, "api", "v1", "testoperator_types.go")
+	content, err := os.ReadFile(typesFile)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(content)).To(ContainSubstring("Size int32 `json:\"size,omitempty\"`"))
+	Expect(string(content)).To(ContainSubstring("Size is the size of the memcached deployment"))
+
+	controllerFile := filepath.Join(projectDir, "internal", "controller", "testoperator_controller.go")
+	content, err = os.ReadFile(controllerFile)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(content)).To(ContainSubstring("Custom reconciliation logic"))
+	Expect(string(content)).To(ContainSubstring("log.Info(\"Reconciling TestOperator\")"))
+	Expect(string(content)).To(ContainSubstring("log.Info(\"TestOperator size\", \"size\", testOperator.Spec.Size)"))
+
+	projectFile := filepath.Join(projectDir, "PROJECT")
+	content, err = os.ReadFile(projectFile)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(content)).To(ContainSubstring("version: \"3\""))
+}

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -68,4 +68,5 @@ function test_cluster {
   go test $(dirname "$0")/deployimage $flags -timeout 30m
   go test $(dirname "$0")/v4 $flags -timeout 30m
   go test $(dirname "$0")/alphagenerate $flags -timeout 30m
+  go test $(dirname "$0")/alphaupdate $flags -timeout 30m
 }


### PR DESCRIPTION
This PR adds a new e2e test for the alpha update command that validates custom code preservation during version updates.

What's Added

- New e2e test suite: test/e2e/alphaupdate/ with focused logging
- Single test case: Validates alpha update preserves custom code during scaffolding updates
- Focused validation: Tests core functionality with potential for future expansion

Test Coverage
The new test validates:

- Alpha update command execution (for now, hardcoded to v4.5.2 → v4.6.0)
- Custom API field preservation during update
- Custom controller logic preservation during update
- Project scaffolding updates correctly

Implementation Details

- Downloads kubebuilder v4.5.2 binary for creating the mock project
- Injects custom code into API types and controller
- Runs alpha update using current kubebuilder binary
- Validates all custom code remains intact after update

Follow-up Work

- Additional validation scenarios (git branches, flags, edge cases) can be added in future iterations.

Test Results

- Integrated into existing e2e test suite
- Clean, readable logging output

```
=== RUN   TestE2E
  Starting kubebuilder suite test for the alpha update command
Running Suite: Kubebuilder alpha update suite - /home/vitor/go/src/github.com/vitorfloriano/kubebuilder/test/e2e/alphaupdate
============================================================================================================================
Random Seed: 1752155135

Will run 1 of 1 specs
------------------------------
kubebuilder alpha update should update project from v4.5.2 to v4.6.0 preserving custom code
/home/vitor/go/src/github.com/vitorfloriano/kubebuilder/test/e2e/alphaupdate/update_test.go:73
  STEP: setting up test context for kubebuilder binary management @ 07/10/25 10:45:35.194
  running: kubectl version -o json
  cleaning up tools
  preparing testing directory: /home/vitor/go/src/github.com/vitorfloriano/kubebuilder/test/e2e/alphaupdate/e2e-apoj
  STEP: creating isolated mock project directory in /tmp to avoid git conflicts @ 07/10/25 10:45:35.966
  STEP: downloading kubebuilder v4.5.2 binary to isolated /tmp directory @ 07/10/25 10:45:35.966
  STEP: creating mock project with kubebuilder v4.5.2 @ 07/10/25 10:45:38.773
  STEP: running kubebuilder init @ 07/10/25 10:45:38.773
  STEP: running kubebuilder create api @ 07/10/25 10:45:48.194
  STEP: running make all @ 07/10/25 10:46:00.432
  STEP: injecting custom code in API and controller @ 07/10/25 10:46:19.907
  STEP: initializing git repository and committing mock project @ 07/10/25 10:46:19.907
  STEP: initializing git repository @ 07/10/25 10:46:19.907
  STEP: adding all files to git @ 07/10/25 10:46:20.003
  STEP: committing initial project state @ 07/10/25 10:46:20.014
  STEP: running alpha update from v4.5.2 to v4.6.0 @ 07/10/25 10:46:20.032
  STEP: validating custom code preservation @ 07/10/25 10:49:11.746
  STEP: cleaning up test artifacts @ 07/10/25 10:49:11.746
  running: docker rmi -f e2e-test/controller-manager:apoj
• [217.025 seconds]
------------------------------

Ran 1 of 1 Specs in 217.027 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (217.03s)
PASS
ok      sigs.k8s.io/kubebuilder/v4/test/e2e/alphaupdate 217.038s
Deleting cluster "local-kubebuilder-e2e" ...
Deleted nodes: ["local-kubebuilder-e2e-control-plane"]
```

Closes: #35 
