### PR TITLE
✨ add --force flag to alpha update command

### DIFF
--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -49,9 +49,8 @@ The process uses Git branches:
   - upgrade: scaffold from the target version
   - merge: result of the 3-way merge
 
-If conflicts occur during the merge, resolve them manually in the 'merge' branch. 
-Once resolved, commit and push it as a pull request. This branch will contain the 
-final upgraded project with the latest Kubebuilder layout and your custom code.
+If conflicts occur during the merge, the command will abort and leave the merge branch for manual resolution.
+Use --force to commit conflicts with markers instead. 
 
 Examples:
   # Update from the version specified in the PROJECT file to the latest release
@@ -62,6 +61,9 @@ Examples:
 
   # Update from a specific version to an specific release
   kubebuilder alpha update --from-version v4.5.0 --to-version v4.7.0	
+
+  # Force update even with merge conflicts (commit conflict markers)
+  kubebuilder alpha update --force
 
 `,
 
@@ -91,6 +93,10 @@ Examples:
 
 	updateCmd.Flags().StringVar(&opts.FromBranch, "from-branch", "",
 		"Git branch to use as current state of the project for the update.")
+
+	updateCmd.Flags().BoolVar(&opts.Force, "force", false,
+		"Force the update even if merge conflicts occur. When conflicts are detected "+
+			"the command will commit the merge with conflict markers instead of aborting.")
 
 	return updateCmd
 }


### PR DESCRIPTION
This PR adds the --force flag to the alpha update command, as well as e2e tests for it. The --force flag makes it possible to run the alpha update command in CI workflows.

Closes #37